### PR TITLE
auto: respect max size of compressed data

### DIFF
--- a/R/dbreg.R
+++ b/R/dbreg.R
@@ -18,7 +18,7 @@
 #' closed before the function exits. Note that a persistent (disk-backed)
 #' database connection is required for larger-than-RAM datasets in order to take
 #' advantage of out-of-core functionality like streaming (where supported).
-#' @param table,data,path Mututally exclusive arguments for specifying the data
+#' @param table,data,path Mutually exclusive arguments for specifying the data
 #' table (object) to be queried. In order of precedence:
 #' - `table`: Character string giving the name of the data table in an
 #' existing (open) database connection.
@@ -41,12 +41,22 @@
 #'   internal heuristics. Users can also override with one of the following
 #'   explicit strategies: `"compress"`, `"mundlak"`, or `"moments"`. See
 #'   the Acceleration Strategies section below for details.
-#' @param threshold Numeric. Threshold for determining the acceleration
-#'   `strategy` under the default `"auto"` option. Maps to the ratio between
-#'   (a) unique values of combined covariates and fixed effects, and (b) total
-#'   rows in the dataset. If this ratio is below the given the given threshold
-#'   (default = 0.1%), then the `"compress"` strategy is used, otherwise
-#'   `"mundlak"` or `"moments"` depending on the number of fixed effects.
+#' @param compress_ratio,compress_nmax Numeric(s). Parameters that help to
+#'   determine the acceleration `strategy` under the default `"auto"` option.
+#'
+#'   - `compress_ratio` defines the compression ratio threshold, i.e. compressed
+#'     data size vs. original data size. An estimated compression ratio larger
+#'     than this threshold indicates poor compression relative to the desired
+#'     level.
+#'   - `compress_nmax` defines the maximum allowable size (in rows) of the
+#'     compressed dataset that can be serialized into R. Pays heed to the idea
+#'     that big data serialization can be costly (esp. for remote databases),
+#'     even if we have achieved good compression on top of the original dataset.
+#'
+#' If both conditions are met, i.e. (1) estimated compression ratio <
+#' `compress_ratio` and (2) estimated compressed data size < `compress_nmax`,
+#' then the `"compress"` strategy is used. Otherwise, either the `"mundlak"` or
+#' `"moments"` strategy will be used, depending on the number of fixed effects.
 #' @param query_only Logical indicating whether only the underlying compression
 #'   SQL query should be returned (i.e., no computation will be performed).
 #'   Default is `FALSE`.
@@ -60,10 +70,11 @@
 #'
 #' @section Acceleration strategies:
 #'
-#' `dbreg` offers three primary acceleration (shortcut) strategies:
+#' `dbreg` offers three primary acceleration (shortcut) strategies for
+#' estimating regression results from simplied data representations:
 #'
-#' 1. `"compress"`: compress the size of data via a `GROUP BY` operation (using regressors + fixed effects) and then run frequency-weighted least squares on the smaller dataset. This procedure follows the "optimal data compression" strategy proposed by Wang et. al. (2021).
-#' 2. `"moments"`: calculate sufficient statistics using global means (\eqn{X'X, X'y}). Limited to cases without fixed effects.
+#' 1. `"compress"`: compress the data via a `GROUP BY` operation (using regressors + fixed effects as groups) and then run frequency-weighted least squares on the smaller dataset. This procedure follows the "optimal data compression" strategy proposed by Wang et. al. (2021).
+#' 2. `"moments"`: calculate sufficient statistics from global means (\eqn{X'X, X'y}), i.e. a single-row data frame computed on the database backend. Limited to cases without fixed effects.
 #' 3. `"mundlak"`: as per `"moments"`, but first subtract group-level means from the observations. Permits at most two fixed-effects (i.e., either demean or double-demean). This procedure follows the "generalized Mundlak estimator" proposed by Arkhangelsky & Imbens (2024).
 #'
 #' The relative efficiency of each of these strategies depends on the size and
@@ -72,7 +83,7 @@
 #' performance gains for "standard" cases, it is less efficient for a true panel
 #' (repeated cross-sections over time), where N >> T. In such cases, it is more
 #' efficient to use a Mundlak-type representation that subtracts group means
-#' first. (Reason: unit and time fixed effects are typically high dimensional,
+#' first. (Reason: unit and time fixed-effects are typically high dimensional,
 #' but covariate averages are not.)
 #'
 #' If the user does not specify an explicit acceleration strategy, then
@@ -80,8 +91,8 @@
 #' some additional overhead, but in most cases should be negligible next to the
 #' overall time savings. The heuristic is as follows:
 #'
-#' - IF no fixed-effects AND (any continuous regressor OR compression ratio > threshold) THEN `"moments"`.
-#' - ELSE IF 1-2 fixed-effects AND estimated compression ratio high (i.e., > max(0.6, threshold)) THEN `"mundlak"`.
+#' - IF no fixed-effects AND (any continuous regressor OR poor compression ratio OR too big compressed data) THEN `"moments"`.
+#' - ELSE IF 1-2 fixed-effects AND (poor compression ratio OR too big compressed data) THEN `"mundlak"`.
 #' - ELSE THEN `"compress"`.
 #'
 #' @references
@@ -130,7 +141,8 @@ dbreg = function(
   path = NULL,
   vcov = c("iid", "hc1"),
   strategy = c("auto", "compress", "moments", "mundlak"),
-  threshold = 0.001,
+  compress_ratio = 0.001,
+  compress_nmax = 1e6,
   query_only = FALSE,
   data_only = FALSE,
   verbose = TRUE
@@ -141,17 +153,18 @@ dbreg = function(
 
   # Process and validate inputs
   inputs = process_dbreg_inputs(
-    fml,
-    conn,
-    table,
-    data,
-    path,
-    vcov,
-    strategy,
-    query_only,
-    data_only,
-    threshold,
-    verbose
+    fml = fml,
+    conn = conn,
+    table = table,
+    data = data,
+    path = path,
+    vcov = vcov,
+    strategy = strategy,
+    query_only = query_only,
+    data_only = data_only,
+    compress_ratio = compress_ratio,
+    compress_nmax = compress_nmax,
+    verbose = verbose
   )
 
   # Choose strategy
@@ -185,7 +198,8 @@ process_dbreg_inputs = function(
   strategy,
   query_only,
   data_only,
-  threshold,
+  compress_ratio,
+  compress_nmax,
   verbose
 ) {
   vcov_type_req = vcov
@@ -292,7 +306,8 @@ process_dbreg_inputs = function(
     strategy = strategy,
     query_only = query_only,
     data_only = data_only,
-    threshold = threshold,
+    compress_ratio = compress_ratio,
+    compress_nmax = compress_nmax,
     verbose = verbose,
     any_continuous = any_continuous,
     own_conn = own_conn
@@ -368,7 +383,8 @@ choose_strategy = function(inputs) {
   fes = inputs$fes
   verbose = inputs$verbose
   any_continuous = inputs$any_continuous
-  threshold = inputs$threshold
+  compress_ratio = inputs$compress_ratio
+  compress_nmax = inputs$compress_nmax
   conn = inputs$conn
   from_statement = inputs$from_statement
   xvars = inputs$xvars
@@ -382,7 +398,7 @@ choose_strategy = function(inputs) {
     from_statement = inputs$from_statement
 
     if (verbose) {
-      message("[dbreg] Estimating compression ratio...")
+      message("[dbreg] Estimating compression ratio and data size...")
     }
     key_cols = c(xvars, fes)
     if (!length(key_cols)) {
@@ -430,7 +446,10 @@ choose_strategy = function(inputs) {
       )
     }
 
-    n_groups_total / max(total_n, 1)
+    comp_rat = n_groups_total / max(total_n, 1)
+    attr(comp_rat, "comp_size") = n_groups_total
+
+    return(comp_rat)
   }
 
   chosen_strategy = strategy
@@ -438,25 +457,32 @@ choose_strategy = function(inputs) {
 
   # Auto logic
   if (strategy == "auto") {
+    est_cr = tryCatch(estimate_compression(inputs), error = function(e) {
+      NA_real_
+    })
+    comp_size = attr(est_cr, "comp_size")
     if (length(fes) == 0) {
-      est_cr = tryCatch(estimate_compression(inputs), error = function(e) {
-        NA_real_
-      })
-      if (any_continuous || (!is.na(est_cr) && est_cr > threshold)) {
+      if (
+        any_continuous ||
+          (!is.na(est_cr) &&
+            (est_cr > compress_ratio || comp_size > compress_nmax))
+      ) {
         chosen_strategy = "moments"
       } else {
         chosen_strategy = "compress"
       }
     } else if (length(fes) %in% c(1, 2)) {
-      est_cr = tryCatch(estimate_compression(inputs), error = function(e) {
-        NA_real_
-      })
-      if (!is.na(est_cr) && est_cr > max(0.6, threshold)) {
+      if (
+        !is.na(est_cr) &&
+          (est_cr > max(0.6, compress_ratio) || comp_size > compress_nmax)
+      ) {
         chosen_strategy = "mundlak"
         if (verbose) {
           message(
-            "[dbreg] Auto: selecting mundlak (estimated compression ratio ",
+            "[dbreg] Auto: selecting mundlak (compression ratio = ",
             sprintf("%.2f", est_cr),
+            ", data size = ",
+            prettyNum(comp_size, big.mark = ","),
             ")."
           )
         }
@@ -464,9 +490,6 @@ choose_strategy = function(inputs) {
         chosen_strategy = "compress"
       }
     } else {
-      est_cr = tryCatch(estimate_compression(inputs), error = function(e) {
-        NA_real_
-      })
       chosen_strategy = "compress"
       if (!is.na(est_cr) && est_cr > 0.8 && verbose) {
         message(sprintf(

--- a/R/dbreg.R
+++ b/R/dbreg.R
@@ -462,29 +462,38 @@ choose_strategy = function(inputs) {
     })
     comp_size = attr(est_cr, "comp_size")
     if (length(fes) == 0) {
-      if (
-        any_continuous ||
-          (!is.na(est_cr) &&
-            (est_cr > compress_ratio || comp_size > compress_nmax))
-      ) {
+      fail_compress_ratio = !is.na(est_cr) && est_cr > compress_ratio
+      fail_compress_nmax = !is.na(est_cr) && comp_size > compress_nmax
+      if (any_continuous || (fail_compress_ratio || fail_compress_nmax)) {
         chosen_strategy = "moments"
       } else {
         chosen_strategy = "compress"
       }
     } else if (length(fes) %in% c(1, 2)) {
-      if (
-        !is.na(est_cr) &&
-          (est_cr > max(0.6, compress_ratio) || comp_size > compress_nmax)
-      ) {
+      fail_compress_ratio = !is.na(est_cr) && est_cr > max(0.6, compress_ratio)
+      fail_compress_nmax = !is.na(est_cr) && comp_size > compress_nmax
+      if (fail_compress_ratio || fail_compress_nmax) {
         chosen_strategy = "mundlak"
         if (verbose) {
-          message(
-            "[dbreg] Auto: selecting mundlak (compression ratio = ",
-            sprintf("%.2f", est_cr),
-            ", data size = ",
-            prettyNum(comp_size, big.mark = ","),
-            ")."
-          )
+          if (fail_compress_ratio) {
+            reason = paste0(
+              "compression ratio (",
+              sprintf("%.2f", est_cr),
+              ") > threshold (",
+              max(0.6, compress_ratio),
+              ")."
+            )
+          } else {
+            reason = paste0(
+              "compressed data size (",
+              prettyNum(comp_size, big.mark = ","),
+              " rows) > threshold (",
+              prettyNum(compress_nmax, big.mark = ","),
+              " rows)."
+            )
+          }
+          message("[dbreg] Auto: ", reason)
+          message("[dbreg] Auto: selecting mundlak")
         }
       } else {
         chosen_strategy = "compress"

--- a/man/dbreg.Rd
+++ b/man/dbreg.Rd
@@ -12,7 +12,8 @@ dbreg(
   path = NULL,
   vcov = c("iid", "hc1"),
   strategy = c("auto", "compress", "moments", "mundlak"),
-  threshold = 0.001,
+  compress_ratio = 0.001,
+  compress_nmax = 1e+06,
   query_only = FALSE,
   data_only = FALSE,
   verbose = TRUE
@@ -32,7 +33,7 @@ closed before the function exits. Note that a persistent (disk-backed)
 database connection is required for larger-than-RAM datasets in order to take
 advantage of out-of-core functionality like streaming (where supported).}
 
-\item{table, data, path}{Mututally exclusive arguments for specifying the data
+\item{table, data, path}{Mutually exclusive arguments for specifying the data
 table (object) to be queried. In order of precedence:
 \itemize{
 \item \code{table}: Character string giving the name of the data table in an
@@ -60,12 +61,23 @@ internal heuristics. Users can also override with one of the following
 explicit strategies: \code{"compress"}, \code{"mundlak"}, or \code{"moments"}. See
 the Acceleration Strategies section below for details.}
 
-\item{threshold}{Numeric. Threshold for determining the acceleration
-\code{strategy} under the default \code{"auto"} option. Maps to the ratio between
-(a) unique values of combined covariates and fixed effects, and (b) total
-rows in the dataset. If this ratio is below the given the given threshold
-(default = 0.1\%), then the \code{"compress"} strategy is used, otherwise
-\code{"mundlak"} or \code{"moments"} depending on the number of fixed effects.}
+\item{compress_ratio, compress_nmax}{Numeric(s). Parameters that help to
+determine the acceleration \code{strategy} under the default \code{"auto"} option.
+\itemize{
+\item \code{compress_ratio} defines the compression ratio threshold, i.e. compressed
+data size vs. original data size. An estimated compression ratio larger
+than this threshold indicates poor compression relative to the desired
+level.
+\item \code{compress_nmax} defines the maximum allowable size (in rows) of the
+compressed dataset that can be serialized into R. Pays heed to the idea
+that big data serialization can be costly (esp. for remote databases),
+even if we have achieved good compression on top of the original dataset.
+}
+
+If both conditions are met, i.e. (1) estimated compression ratio <
+\code{compress_ratio} and (2) estimated compressed data size < \code{compress_nmax},
+then the \code{"compress"} strategy is used. Otherwise, either the \code{"mundlak"} or
+\code{"moments"} strategy will be used, depending on the number of fixed effects.}
 
 \item{query_only}{Logical indicating whether only the underlying compression
 SQL query should be returned (i.e., no computation will be performed).
@@ -93,7 +105,7 @@ sufficient statistics.
 \code{dbreg} offers three primary acceleration (shortcut) strategies:
 \enumerate{
 \item \code{"compress"}: compress the size of data via a \verb{GROUP BY} operation (using regressors + fixed effects) and then run frequency-weighted least squares on the smaller dataset. This procedure follows the "optimal data compression" strategy proposed by Wang et. al. (2021).
-\item \code{"moments"}: calculate sufficient statistics using global means (\eqn{X'X, X'y}). Limited to cases without fixed effects.
+\item \code{"moments"}: calculate sufficient statistics from global means (\eqn{X'X, X'y}), i.e. a single-row data frame computed on the database backend. Limited to cases without fixed effects.
 \item \code{"mundlak"}: as per \code{"moments"}, but first subtract group-level means from the observations. Permits at most two fixed-effects (i.e., either demean or double-demean). This procedure follows the "generalized Mundlak estimator" proposed by Arkhangelsky & Imbens (2024).
 }
 
@@ -103,7 +115,7 @@ fixed-effects. While the compression approach can yield remarkable
 performance gains for "standard" cases, it is less efficient for a true panel
 (repeated cross-sections over time), where N >> T. In such cases, it is more
 efficient to use a Mundlak-type representation that subtracts group means
-first. (Reason: unit and time fixed effects are typically high dimensional,
+first. (Reason: unit and time fixed-effects are typically high dimensional,
 but covariate averages are not.)
 
 If the user does not specify an explicit acceleration strategy, then
@@ -111,15 +123,15 @@ If the user does not specify an explicit acceleration strategy, then
 some additional overhead, but in most cases should be negligible next to the
 overall time savings. The heuristic is as follows:
 \itemize{
-\item IF no fixed-effects AND (any continuous regressor OR compression ratio > threshold) THEN \code{"moments"}.
-\item ELSE IF 1-2 fixed-effects AND estimated compression ratio high (i.e., > max(0.6, threshold)) THEN \code{"mundlak"}.
+\item IF no fixed-effects AND (any continuous regressor OR poor compression ratio OR too big compressed data) THEN \code{"moments"}.
+\item ELSE IF 1-2 fixed-effects AND (poor compression ratio OR too big compressed data) THEN \code{"mundlak"}.
 \item ELSE THEN \code{"compress"}.
 }
 }
 
 \examples{
 
-# A not very compelling example using a small in-memory dataset:
+# A not very compelling example using a small iin-memory dataset:
 (mod = dbreg(Temp ~ Wind | Month, data = airquality))
 
 # Same result as lm

--- a/man/process_dbreg_inputs.Rd
+++ b/man/process_dbreg_inputs.Rd
@@ -14,7 +14,8 @@ process_dbreg_inputs(
   strategy,
   query_only,
   data_only,
-  threshold,
+  compress_ratio,
+  compress_nmax,
   verbose
 )
 }


### PR DESCRIPTION
Closes #9

MWE:

``` r
pkgload::load_all("~/Documents/Projects/dbreg/")
#> ℹ Loading dbreg
data("trade", package = "fixest")

dbreg(Euros ~ dist_km | Destination + Origin, data = trade, compress_nmax = 100)
#> [dbreg] Estimating compression ratio and data size...
#> [dbreg] Data has 38,325 rows and 210 unique FE groups.
#> [dbreg] Auto: compressed data size (210 rows) > threshold (100 rows).
#> [dbreg] Auto: selecting mundlak
#> [dbreg] Using strategy: mundlak
#> [dbreg] Executing mundlak SQL
#> Two-way Mundlak OLS estimation, Dep. Var.: Euros 
#> Observations.: 38,325 
#> Standard Errors: IID 
#>         Estimate Std. Error  t value  Pr(>|t|)    
#> dist_km -47016.3    1424.11 -33.0145 < 2.2e-16 ***
#> ---
#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
```

<sup>Created on 2025-08-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


Two comments for you @jamesbrandecon:

- I reverted the `threshold` argument back to `compress_ratio` to pair better with the new `compress_nmax` argument. (Sorry for making you switch in the first place!)
- I might be forgetting something, but you can explain a bit more why the compression ratio threshold changes to `max(0.6, threshold)` in the presence of fixed effects? See: https://github.com/grantmcdermott/dbreg/blob/b347565ef462e7b80ff2d9982ce74126c9e36279/R/dbreg.R#L454 The normal threshold (compress_ratio) is so much lower at 0.001 that it will almost never be binding for this common case. Why don't we set it at 0.6 (or even lower) as the default and drop the `max(0.6, threshold)` part?